### PR TITLE
adds listener to beforePushed events

### DIFF
--- a/lib/behavior/events.js
+++ b/lib/behavior/events.js
@@ -6,6 +6,17 @@ events.beforeInsert = function() {
   Class.getBehavior('timestamp').setCreationDate(doc);
 };
 
+events.beforePushed = function() {
+  var doc = this;
+  var Class = doc.constructor;
+
+  if(doc._isNew) {
+    Class.getBehavior('timestamp').setCreationDate(doc);
+  } else {
+    Class.getBehavior('timestamp').setModificationDate(doc);
+  }
+};
+
 events.beforeUpdate = function() {
   var doc = this;
   var Class = doc.constructor;


### PR DESCRIPTION
The meteor-astronomy-timestamp-behavior does not work for nested documents.

This PR aims to solve this problem.
