### PR TITLE
Correct field types to Date

### DIFF
--- a/lib/behavior/behavior.js
+++ b/lib/behavior/behavior.js
@@ -54,7 +54,7 @@ Astro.Behavior.create({
     if (options.hasCreatedField) {
       // Add a field for storing a creation date.
       schemaDefinition.fields[options.createdFieldName] = {
-        type: 'date',
+        type: Date,
         immutable: true,
         default: null
       };
@@ -63,7 +63,7 @@ Astro.Behavior.create({
     if (options.hasUpdatedField) {
       // Add a field for storing an update date.
       schemaDefinition.fields[options.updatedFieldName] = {
-        type: 'date',
+        type: Date,
         optional: true,
         default: null
       };


### PR DESCRIPTION
Just a quick fix to get the v2 behavior working.  Have briefly tested and it works on my project.  The field definitions still had the old ones on your version.
