### PR TITLE
Enable lazy loading

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,5 +14,5 @@ Package.onUse(function(api) {
     'jagi:astronomy@2.0.0'
   ], ['client', 'server']);
 
-  api.mainModule('lib/main.js', ['client', 'server']);
+  api.mainModule('lib/main.js', ['client', 'server'], { lazy: true });
 });


### PR DESCRIPTION
Using this package forces also `jagi:astronomy` to be bundled on the initial static client bundle. Adding `{ lazy: true }` should exclude this package (and therefore `jagi:astronomy`) from the static bundle, unless specifically imported.